### PR TITLE
Compatibilidad con Angular 9.1

### DIFF
--- a/src/rut-value-accessor.ts
+++ b/src/rut-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { rutFormat } from 'rut-helpers';
 
-import { ElementRef, Renderer } from '@angular/core';
+import { ElementRef, Renderer2 } from '@angular/core';
 
 const RUT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
En el momento que se utiliza con Angular 9.1, el validador de RUT no funciona debido a que no encuntra la librería Render. Sugiere utilizar la Librería Render2