### PR TITLE
Compatibilidad con Angular 9.1

### DIFF
--- a/src/rut-value-accessor.ts
+++ b/src/rut-value-accessor.ts
@@ -20,7 +20,7 @@ const RUT_VALUE_ACCESSOR: any = {
 })
 export class RutValueAccessor implements ControlValueAccessor {
   constructor(
-    private renderer: Renderer,
+    private renderer: Renderer2,
     private elementRef: ElementRef,
     ) { }
 

--- a/src/rut-value-accessor.ts
+++ b/src/rut-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, forwardRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { rutFormat } from 'rut-helpers';
 
-import { ElementRef, Renderer } from '@angular/core';
+import { ElementRef, Renderer2 } from '@angular/core';
 
 const RUT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -29,7 +29,7 @@ export class RutValueAccessor implements ControlValueAccessor {
 
   public writeValue(value: any): void {
     let normalizedValue: string = rutFormat(value) || '';
-    this.renderer.setElementProperty(this.elementRef.nativeElement, 'value', normalizedValue);
+    this.renderer.setProperty(this.elementRef.nativeElement, 'value', normalizedValue);
   }
 
   public registerOnChange(fn: (_: any) => void): void { this.onChange = fn; }


### PR DESCRIPTION
Corresponde al pull request @ #27 : 
"En el momento que se utiliza con Angular 9.1, el validador de RUT no funciona debido a que no encuentra la librería Render. Sugiere utilizar la Librería Render2"